### PR TITLE
Use custom toolset root in setuptool build

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ If you only need to use python you can install it directly through pip:
 
     pip install --user git+https://github.com/IceCubeOpenSource/nuflux
 
+Note that this may fail if photospline and boost_python are installed in nonstandard locations, e.g. headers in /opt/toolsets/mystuff/include, libraries in /opt/toolsets/mystuff/lib. In this case, set the `PREFIX` environment variable to the root of your toolset installation:
+
+    PREFIX=/opt/toolsets/mystuff pip install --user git+https://github.com/IceCubeOpenSource/nuflux
+
 If you want to use nuflux from a c++ program you need to install it with meson
 
     git clone https://github.com/IceCubeOpenSource/nuflux

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
 import sys
+import os
 from setuptools import setup, Extension ,find_packages
 import numpy
 
 boost_python = 'boost_python'+str(sys.version_info.major)+str(sys.version_info.minor)
+prefix = os.environ.get('PREFIX', '/usr/local')
 
 extension = Extension(
     'nuflux._nuflux',
@@ -16,7 +18,8 @@ extension = Extension(
      'src/pybindings/detail.cxx',     
      'src/pybindings/module.cxx',
     ],
-    include_dirs=['src/include',numpy.get_include()],
+    include_dirs=['src/include',numpy.get_include(),os.path.join(prefix,'include')],
+    library_dirs=[os.path.join(prefix,'lib'),os.path.join(prefix,'lib64')]
     libraries=[boost_python,'photospline'],
     extra_compile_args=['-std=c++11','-DUSE_NUMPY'],
     )


### PR DESCRIPTION
Updates setup.py to resolve issue with compilation fail when photospline and boost are not being installed to default locations. Updates README file. 